### PR TITLE
PostgreSQL SSL connection in Digital Ocean

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -42,7 +42,10 @@ export class PostgreSQL {
     database: process.env.DB_DATABASE as string,
     password: process.env.DB_PASSWORD as string,
     port: parseInt(process.env.DB_PORT as string, 10),
-    ssl: process.env.NODE_ENV == 'production' ? true : false,
+    ssl: process.env.NODE_ENV == 'production' ? {
+      rejectUnauthorized : false,
+      ca: process.env.DB_CA_CERT,
+    } : false,
   })
 
   /**


### PR DESCRIPTION
Better pg Pool config object using the (hopefully) proper `ssl` setting for digital ocean.

Fixes #57 

